### PR TITLE
Fix validation error

### DIFF
--- a/src/kicadgen/extractor.py
+++ b/src/kicadgen/extractor.py
@@ -210,7 +210,7 @@ def extract(
     """
     prompt = build_prompt(part_number)
 
-    last_error = None
+    last_error: json.JSONDecodeError | ValueError | None = None
     for attempt in range(max_retries):
         logger.debug(
             f"Extraction attempt {attempt + 1}/{max_retries} for {part_number}"

--- a/src/kicadgen/extractor.py
+++ b/src/kicadgen/extractor.py
@@ -1,10 +1,13 @@
 """VLM-based extraction of component specifications from datasheet images."""
 
 import json
+import logging
 from typing import Any
 
 from kicadgen.schema import ComponentSpec
 from kicadgen.vlm_client import VLMClient
+
+logger = logging.getLogger(__name__)
 
 
 class ExtractionError(Exception):
@@ -92,6 +95,33 @@ Your task is to extract component specifications from the provided datasheet ima
 **JSON Schema:**
 {json_schema}
 
+**IMPORTANT FIELD CATEGORIZATION:**
+
+CRITICAL FIELDS (must always be extracted, never null):
+- component.name: Component model/part name
+- component.part_number: Part identifier
+- component.manufacturer: Manufacturer name
+- component.package_type: Package type (QFN, DIP, SOIC, etc.)
+- symbol.pin_count: Total number of pins
+- symbol.pins[]: Pin list with:
+  - number: Pin identifier (1, 2, 3, A1, etc.)
+  - name: Pin name (VCC, GND, DATA, CLK, etc.)
+  - type: Pin type (input, output, power_in, power_out, passive, bidirectional)
+- footprint.pin_count: Total pins for footprint
+- footprint.pad_type: Either "smd" or "through_hole"
+
+FIELDS WITH SYSTEM DEFAULTS (can be null, system will fill them):
+- symbol.pin_pitch_grid: Defaults to 2.54mm if null
+- symbol.reference_prefix: Defaults to "U" if null
+- component.description: Can be null (optional metadata)
+- component.datasheet_source: Can be null (optional metadata)
+
+FIELDS THAT CAN BE NULL (geometric/optional):
+- footprint.pitch_mm, body_width_mm, body_length_mm, pins_per_side
+- All other footprint fields and pad details
+
+If a critical field is truly unclear from the datasheet, document it in metadata.missing_fields and metadata.assumptions, but still provide your best extraction attempt.
+
 **Component Information:**
 The component part number is: {part_number}
 
@@ -105,6 +135,30 @@ Return ONLY the JSON object, starting with {{ and ending with }}, with no additi
 """
 
     return prompt
+
+
+def apply_schema_defaults(data: dict[str, Any]) -> dict[str, Any]:
+    """Apply schema-defined defaults to extracted data before Pydantic validation.
+
+    Fields that the LLM may return as null but the system has defaults for:
+    - symbol.pin_pitch_grid defaults to 2.54mm
+    - symbol.reference_prefix defaults to "U"
+
+    Args:
+        data: Extracted data dictionary with potentially null optional fields
+
+    Returns:
+        Dictionary with defaults applied to null fields
+    """
+    if "symbol" in data:
+        if data["symbol"].get("pin_pitch_grid") is None:
+            data["symbol"]["pin_pitch_grid"] = 2.54
+            logger.debug("Applied default pin_pitch_grid: 2.54mm")
+        if data["symbol"].get("reference_prefix") is None:
+            data["symbol"]["reference_prefix"] = "U"
+            logger.debug("Applied default reference_prefix: U")
+
+    return data
 
 
 def parse_json_from_response(text: str) -> dict[str, Any]:
@@ -158,16 +212,27 @@ def extract(
 
     last_error = None
     for attempt in range(max_retries):
+        logger.debug(
+            f"Extraction attempt {attempt + 1}/{max_retries} for {part_number}"
+        )
         try:
             response = client.call(images, prompt)
             data = parse_json_from_response(response)
+            # Apply schema-defined defaults before validation
+            data = apply_schema_defaults(data)
             spec = ComponentSpec(**data)
+            logger.debug(f"Extraction succeeded on attempt {attempt + 1}")
             return spec
-        except (json.JSONDecodeError, ValueError) as e:
+        except json.JSONDecodeError as e:
             last_error = e
-            # Continue to next retry
+            logger.debug(f"Attempt {attempt + 1}: JSON parse error: {e}")
+            continue
+        except ValueError as e:
+            last_error = e
+            logger.debug(f"Attempt {attempt + 1}: Schema validation error: {e}")
             continue
 
+    logger.error(f"Failed to extract after {max_retries} attempts for {part_number}")
     raise ExtractionError(
         f"Failed to extract component specification after {max_retries} attempts. "
         f"Last error: {last_error}"

--- a/src/kicadgen/schema.py
+++ b/src/kicadgen/schema.py
@@ -50,9 +50,13 @@ class ComponentInfo(BaseModel):
     name: str = Field(..., description="Human readable component name")
     manufacturer: str = Field(..., description="Manufacturer name")
     part_number: str = Field(..., description="Official part number")
-    description: str = Field(..., description="Short functional description")
+    description: str | None = Field(
+        default=None, description="Short functional description"
+    )
     package_type: str = Field(..., description="Package name (e.g., SOIC-8, QFN-32)")
-    datasheet_source: str = Field(..., description="Datasheet filename or URL")
+    datasheet_source: str | None = Field(
+        default=None, description="Datasheet filename or URL"
+    )
 
 
 class MetadataSpec(BaseModel):
@@ -76,11 +80,13 @@ class SymbolSpec(BaseModel):
     """Symbol specification for KiCAD generation."""
 
     pin_count: int = Field(..., gt=0, description="Total number of pins in symbol")
-    pin_pitch_grid: float = Field(
-        default=2.54, description="Pin pitch grid in millimeters"
+    pin_pitch_grid: float | None = Field(
+        default=None,
+        description="Pin pitch grid in millimeters (defaults to 2.54mm if null)",
     )
-    reference_prefix: str = Field(
-        default="U", description="Reference designator prefix (e.g., 'U', 'R', 'C')"
+    reference_prefix: str | None = Field(
+        default=None,
+        description="Reference designator prefix (defaults to 'U' if null)",
     )
     pins: list[PinSpec] = Field(..., description="List of pins in the symbol")
 


### PR DESCRIPTION
## Context
The extraction pipeline is failing because the LLM returns None for required fields (component.name, component.description, component.package_type, symbol.pin_pitch_grid, symbol.reference_prefix, symbol.pins[].name, symbol.pins[].type). This causes Pydantic validation to reject the extracted data with "Input should be a valid string/float" errors.                 
                                                                                                                             
The root cause: The current prompt tells the LLM "missing or unclear values must be null", but doesn't adequately distinguish
- Truly required fields that must always have values                                                                         
- Optional fields with defaults that can fall back to schema-defined defaults                                                
- Optional fields that can legitimately be null                                                                              
                                                                                                                             
## Solution Overview: Hybrid Approach                                                                                           
                                                                                                                             
Goal: Let the LLM safely return null for uncertain/optional fields, while keeping critical fields required.                  
                                                                                                                             
A three-part approach:                                                                                                       
                                                                                                                             
1. Schema Update (schema.py): Make fields with known fallback defaults truly Optional, allowing the LLM to return null withou
2. Prompt Enhancement (extractor.py): Explicitly tell the LLM which fields are CRITICAL (must never be null) vs which have fa
3. Post-Processing (extractor.py): Fill in schema-defined defaults immediately after JSON parsing, before Pydantic validation
