### PR TITLE
Skip VLM Extraction When --input-json Is Provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ The tool is not intended to be publicly exposed on the internet.
 
 ```
 CLI
- ↓
-PDF Parsing (Local)
- ↓
-Target Page Selection
- ↓
-Image Conversion (PNG)
- ↓
-VLM API Call
- ↓
-Structured JSON Extraction
+ ├─ Option A: Extract from PDF
+ │   ├─ PDF Parsing (Local)
+ │   ├─ Target Page Selection
+ │   ├─ Image Conversion (PNG)
+ │   ├─ VLM API Call
+ │   └─ Structured JSON Extraction
+ │
+ └─ Option B: Load from JSON (skip VLM)
+     └─ Load Pre-extracted JSON
+
  ↓
 [Human Review] ← pauses for user confirmation
  ↓
@@ -57,6 +57,8 @@ KiCAD File Generation
  ↓
 Output
 ```
+
+**Note:** When `--input-json` is provided, stages 1–5 (PDF processing and VLM extraction) are skipped entirely.
 
 ---
 
@@ -77,24 +79,31 @@ Recommended: GPT-4o (high JSON formatting reliability)
 ## 5.1 CLI Interface
 
 ```bash
+# Option 1: Extract from PDF using VLM
 kicadgen <input.pdf> \
   --part-number <string> \
   --model <model_name> \
+  --out <output_dir>
+
+# Option 2: Use pre-extracted JSON (skip VLM extraction)
+kicadgen --input-json <extracted.json> \
+  --part-number <string> \
   --out <output_dir>
 ```
 
 ### Required Arguments
 
-- `input.pdf`
+- Either `input.pdf` **OR** `--input-json` (mutually exclusive)
 - `--part-number`
 
 ### Optional Arguments
 
-- `--model` (default: gpt-4o)
+- `--model` (default: gpt-4o) — only used when extracting from PDF
 - `--out` (default: ./out)
 - `--verbose`
 - `--dry-run`
 - `--no-review` (skip human review of extracted JSON)
+- `--input-json` (path to pre-extracted JSON; skips PDF/VLM stages)
 
 ---
 
@@ -130,6 +139,40 @@ After AI extraction, before validation, the pipeline pauses for human review:
 - User can:
   - Press **Enter** or type **`y`** → continue to validation
   - Type **`n`** or **`q`** → abort pipeline (exit code 1)
+
+---
+
+## 5.5 Pre-extracted JSON Input
+
+Users can provide a pre-extracted JSON file via `--input-json` to skip the entire VLM extraction stage:
+
+```bash
+kicadgen --input-json /path/to/extracted.json \
+  --part-number STM32H743 \
+  --no-review
+```
+
+**Benefits:**
+- Skip expensive VLM API calls (no API credits consumed)
+- Re-use extraction from prior runs
+- Hand-craft or modify extracted data before generation
+- Faster iteration for KiCAD generation tuning
+
+**Workflow example:**
+```bash
+# 1. Extract from PDF (generates out/<timestamp>/extracted.json)
+kicadgen datasheet.pdf --part-number STM32H743 --no-review
+
+# 2. (Optional) Manually edit extracted.json to fix extraction errors
+
+# 3. Re-run from saved JSON, skip VLM stage
+kicadgen --input-json ./out/<timestamp>/extracted.json --part-number STM32H743 --no-review
+```
+
+**Requirements:**
+- JSON file must conform to the schema (see Section 7)
+- Must be valid JSON parseable by `ComponentSpec.model_validate_json()`
+- Input JSON is copied to output directory as `extracted.json`
 
 ---
 
@@ -250,11 +293,17 @@ Setup verbose/quiet logging based on CLI flags.
 Depends on: all modules
 
 Orchestrates the full workflow:
-1. Load PDF
-2. Select relevant pages
-3. Render to PNG images
-4. Call VLM extraction
-5. Save extracted.json
+
+**Branching logic:**
+- If `--input-json` provided: Load pre-extracted JSON directly (skip stages 1–5)
+- Otherwise: Execute full extraction pipeline
+
+**Full pipeline stages:**
+1. Load PDF (or skip if using `--input-json`)
+2. Select relevant pages (or skip)
+3. Render to PNG images (or skip)
+4. Call VLM extraction (or skip)
+5. Save extracted.json (or copy from input if using `--input-json`)
 6. **[Human Review]** — prompt user to review extracted data (unless --no-review)
 7. Validate results
 8. Generate KiCAD files (if valid)
@@ -269,13 +318,16 @@ Orchestrates the full workflow:
 Depends on: `pipeline.py`
 
 argparse-based CLI with arguments:
-- `input_pdf` (positional, required)
+- `input_pdf` (positional, optional) — required unless `--input-json` is provided
 - `--part-number` (required)
-- `--model` (default: `gpt-4o`)
+- `--input-json` (optional) — path to pre-extracted JSON; skips PDF/VLM stages
+- `--model` (default: `gpt-4o`) — only used when extracting from PDF
 - `--out` (default: `./out`)
 - `--verbose` (flag)
 - `--dry-run` (flag)
 - `--no-review` (flag) — skip human review step before validation
+
+**Validation:** Either `input_pdf` or `--input-json` must be provided, but not both.
 
 ## 6.3 Dependencies (pyproject.toml)
 

--- a/src/kicadgen/cli.py
+++ b/src/kicadgen/cli.py
@@ -15,10 +15,12 @@ def main() -> int:
         prog="kicadgen",
     )
 
-    # Positional argument
+    # Positional argument (optional if --input-json is provided)
     parser.add_argument(
         "input_pdf",
-        help="Path to the component datasheet PDF",
+        nargs="?",
+        default=None,
+        help="Path to the component datasheet PDF (not required if --input-json is provided)",
     )
 
     # Required optional arguments
@@ -26,6 +28,14 @@ def main() -> int:
         "--part-number",
         required=True,
         help="Component part number (e.g., STM32H743)",
+    )
+
+    # JSON input option (skips VLM extraction)
+    parser.add_argument(
+        "--input-json",
+        metavar="PATH",
+        default=None,
+        help="Path to a pre-extracted JSON file; skips VLM extraction stage",
     )
 
     # Optional arguments
@@ -61,6 +71,17 @@ def main() -> int:
     )
 
     args = parser.parse_args()
+
+    # Validate that either input_pdf or --input-json is provided, but not both
+    if args.input_pdf is None and args.input_json is None:
+        parser.error(
+            "either INPUT_PDF or --input-json must be provided"
+        )
+
+    if args.input_pdf is not None and args.input_json is not None:
+        parser.error(
+            "cannot provide both INPUT_PDF and --input-json; choose one"
+        )
 
     from kicadgen.pipeline import run
 

--- a/src/kicadgen/cli.py
+++ b/src/kicadgen/cli.py
@@ -74,14 +74,10 @@ def main() -> int:
 
     # Validate that either input_pdf or --input-json is provided, but not both
     if args.input_pdf is None and args.input_json is None:
-        parser.error(
-            "either INPUT_PDF or --input-json must be provided"
-        )
+        parser.error("either INPUT_PDF or --input-json must be provided")
 
     if args.input_pdf is not None and args.input_json is not None:
-        parser.error(
-            "cannot provide both INPUT_PDF and --input-json; choose one"
-        )
+        parser.error("cannot provide both INPUT_PDF and --input-json; choose one")
 
     from kicadgen.pipeline import run
 

--- a/src/kicadgen/pipeline.py
+++ b/src/kicadgen/pipeline.py
@@ -129,12 +129,6 @@ def run(args) -> int:
     # Set up logging
     logger = setup_logger(__name__, verbose=args.verbose)
 
-    # Validate input file
-    input_path = Path(args.input_pdf)
-    if not input_path.exists():
-        logger.error(f"Input PDF not found: {input_path}")
-        return 1
-
     # Create output directory with timestamp subdirectory
     output_dir = Path(args.out)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -144,34 +138,57 @@ def run(args) -> int:
     timestamped_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        # Load PDF
-        logger.info(f"Loading PDF: {input_path}")
-        doc = fitz.open(input_path)
+        # Branch: load from pre-extracted JSON or run full extraction pipeline
+        if args.input_json:
+            # Skip VLM extraction; load from pre-extracted JSON
+            input_json_path = Path(args.input_json)
+            if not input_json_path.exists():
+                logger.error(f"Input JSON not found: {input_json_path}")
+                return 1
 
-        # Select relevant pages
-        logger.info("Selecting relevant pages...")
-        page_indices = select_relevant_pages(doc, KEYWORDS)
-        if not page_indices:
-            logger.warning("No relevant pages found; using first page")
-            page_indices = [0]
+            logger.info(f"Loading pre-extracted specification from: {input_json_path}")
+            spec = ComponentSpec.model_validate_json(input_json_path.read_text())
 
-        # Render pages to images
-        logger.info(f"Rendering {len(page_indices)} page(s) to PNG...")
-        with TempImageDir():
-            images = render_pages_to_png(doc, page_indices, dpi=300)
+            # Copy input JSON to output directory as extracted.json
+            extracted_path = timestamped_dir / "extracted.json"
+            extracted_path.write_text(input_json_path.read_text())
+            logger.info(f"Copied extracted specification to {extracted_path}")
+        else:
+            # Full extraction pipeline: PDF → pages → render → VLM → JSON
+            # Validate input file
+            input_path = Path(args.input_pdf)
+            if not input_path.exists():
+                logger.error(f"Input PDF not found: {input_path}")
+                return 1
 
-            # Get VLM client
-            logger.info(f"Initializing VLM client for model: {args.model}")
-            client = get_client(args.model)
+            # Load PDF
+            logger.info(f"Loading PDF: {input_path}")
+            doc = fitz.open(input_path)
 
-            # Extract component specification
-            logger.info("Extracting component specification from VLM...")
-            spec = extract(client, images, args.part_number)
+            # Select relevant pages
+            logger.info("Selecting relevant pages...")
+            page_indices = select_relevant_pages(doc, KEYWORDS)
+            if not page_indices:
+                logger.warning("No relevant pages found; using first page")
+                page_indices = [0]
 
-        # Save extracted JSON
-        extracted_path = timestamped_dir / "extracted.json"
-        extracted_path.write_text(spec.model_dump_json(indent=2))
-        logger.info(f"Saved extracted specification to {extracted_path}")
+            # Render pages to images
+            logger.info(f"Rendering {len(page_indices)} page(s) to PNG...")
+            with TempImageDir():
+                images = render_pages_to_png(doc, page_indices, dpi=300)
+
+                # Get VLM client
+                logger.info(f"Initializing VLM client for model: {args.model}")
+                client = get_client(args.model)
+
+                # Extract component specification
+                logger.info("Extracting component specification from VLM...")
+                spec = extract(client, images, args.part_number)
+
+            # Save extracted JSON
+            extracted_path = timestamped_dir / "extracted.json"
+            extracted_path.write_text(spec.model_dump_json(indent=2))
+            logger.info(f"Saved extracted specification to {extracted_path}")
 
         # Human review (unless --no-review)
         if not args.no_review:


### PR DESCRIPTION
## Context
The kicadgen pipeline currently always runs the full VLM extraction pipeline (PDF loading → page selection → rendering → VLM API call → JSON parsing). This is slow and costs API credits. Users who already have a valid extracted.json (e.g., from a prior run they want to re-use or a hand-crafted file) have no way to skip straight to validation and KiCAD generation. Adding --input-json allows users to supply a pre-extracted JSON file and bypass stages 1–5 entirely.

##  Code Changes

  cli.py (2 changes):
  - Made input_pdf optional with nargs='?' and default=None
  - Added --input-json argument for pre-extracted JSON input
  - Added validation logic to ensure either input_pdf or --input-json is provided (but not both)

  pipeline.py (1 change):
  - Added branching logic at the start of run():
    - If --input-json is provided: Load ComponentSpec directly from the JSON file and copy it to extracted.json
    - Otherwise: Execute the full extraction pipeline (PDF → pages → render → VLM → JSON)
  - Rest of the pipeline (review, validation, KiCAD generation) runs unchanged

##  Documentation Updates (README.md)

  - Section 3: Updated System Architecture diagram to show branching (Option A: PDF extraction vs Option B: pre-extracted JSON)
  - Section 5.1: Updated CLI Interface with both usage patterns
  - Section 5.5: Added new "Pre-extracted JSON Input" section with:
    - Usage example
    - Benefits (skip API calls, re-use extractions, hand-craft data, faster iteration)
    - Workflow example showing full pipeline → manual edit → re-run from JSON
    - Requirements for the JSON file
  - Section 6.2: Updated pipeline.py and cli.py documentation to reflect the new branching logic